### PR TITLE
v1.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.0.1
+mod_version=1.6-fabric-1.1.0
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=fossiltweaks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.0.0
+mod_version=1.6-fabric-1.0.1
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=fossiltweaks
 

--- a/src/main/java/us/timinc/mc/cobblemon/fossiltweaks/mixins/FossilMultiblockStructureMixin.java
+++ b/src/main/java/us/timinc/mc/cobblemon/fossiltweaks/mixins/FossilMultiblockStructureMixin.java
@@ -11,17 +11,11 @@ import us.timinc.mc.cobblemon.fossiltweaks.FossilTweaks;
 
 @Mixin(FossilMultiblockStructure.class)
 public class FossilMultiblockStructureMixin {
-
     @Shadow
     private int timeRemaining;
 
-    @Inject(method = "tick", at = @At("HEAD"), remap = false)
-    private void tick(World world, CallbackInfo ci) {
-        if (!world.isClient) {
-            int target = FossilTweaks.config.getFossilMachineTicks();
-            if (this.timeRemaining == 14400 && target != 14400) {
-                this.timeRemaining = target;
-            }
-        }
+    @Inject(method = "startMachine", at = @At("TAIL"), remap = false)
+    private void startMachineMixin(World world, CallbackInfo ci) {
+        this.timeRemaining = us.timinc.mc.cobblemon.fossiltweaks.FossilTweaks.config.getFossilMachineTicks();
     }
 }

--- a/src/main/java/us/timinc/mc/cobblemon/fossiltweaks/mixins/FossilMultiblockStructureMixin.java
+++ b/src/main/java/us/timinc/mc/cobblemon/fossiltweaks/mixins/FossilMultiblockStructureMixin.java
@@ -1,13 +1,10 @@
 package us.timinc.mc.cobblemon.fossiltweaks.mixins;
 
-import com.cobblemon.mod.common.block.multiblock.FossilMultiblockStructure;
-import net.minecraft.world.World;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import us.timinc.mc.cobblemon.fossiltweaks.FossilTweaks;
+import com.cobblemon.mod.common.block.multiblock.*;
+import net.minecraft.world.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
 
 @Mixin(FossilMultiblockStructure.class)
 public class FossilMultiblockStructureMixin {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/FossilTweaks.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/FossilTweaks.kt
@@ -15,7 +15,7 @@ object FossilTweaks : ModInitializer {
     lateinit var config: MainConfig
 
     override fun onInitialize() {
-        config = ConfigBuilder.load(MainConfig::class.java, MOD_ID);
+        config = ConfigBuilder.load(MainConfig::class.java, MOD_ID)
 
         CobblemonEvents.FOSSIL_REVIVED.subscribe { evt ->
             val pokemon = evt.pokemon

--- a/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/FossilTweaks.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/FossilTweaks.kt
@@ -1,6 +1,7 @@
 package us.timinc.mc.cobblemon.fossiltweaks
 
 import com.cobblemon.mod.common.api.events.CobblemonEvents
+import com.cobblemon.mod.common.api.events.pokemon.ShinyChanceCalculationEvent
 import net.fabricmc.api.ModInitializer
 import us.timinc.mc.cobblemon.fossiltweaks.config.ConfigBuilder
 import us.timinc.mc.cobblemon.fossiltweaks.config.MainConfig
@@ -18,10 +19,19 @@ object FossilTweaks : ModInitializer {
 
         CobblemonEvents.FOSSIL_REVIVED.subscribe { evt ->
             val pokemon = evt.pokemon
-            val roll = Random.nextInt(config.fossilShinyRate)
-            if (roll == 0) {
-                pokemon.shiny = true
+            val player = evt.player
+
+            pokemon.persistentData.putBoolean("ft_isFossil", true)
+
+            var shinyRate = config.fossilShinyRate
+            CobblemonEvents.SHINY_CHANCE_CALCULATION.post(ShinyChanceCalculationEvent(shinyRate, pokemon)) { event ->
+                shinyRate = event.calculate(player)
             }
+
+            pokemon.shiny = shinyRate.checkRate()
         }
     }
+
+    private fun Float.checkRate(): Boolean =
+        if (this >= 1) (Random.Default.nextFloat() < 1 / this) else Random.Default.nextFloat() < this
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/config/MainConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/fossiltweaks/config/MainConfig.kt
@@ -2,5 +2,5 @@ package us.timinc.mc.cobblemon.fossiltweaks.config
 
 class MainConfig {
     val fossilMachineTicks: Int = 14400
-    val fossilShinyRate: Int = 8192
+    val fossilShinyRate: Float = 8192F
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon_fossiltweaks",
-  "version": "1.6-fabric-1.0.0",
+  "version": "1.6-fabric-1.0.1",
   "name": "Cobblemon Fossil Tweaks",
   "description": "Tweak the Cobblemon fossil workflow as you please!",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon_fossiltweaks",
-  "version": "1.6-fabric-1.0.1",
+  "version": "1.6-fabric-1.1.0",
   "name": "Cobblemon Fossil Tweaks",
   "description": "Tweak the Cobblemon fossil workflow as you please!",
   "authors": [


### PR DESCRIPTION
* fixed time remaining not working all the time.
* took advantage of the new shiny calculation event from Cobblemon, marking the Pokemon as `ft_isFossil` beforehand in case someone wanted to check.